### PR TITLE
update wasmtime dep and enable `concurrent_{imports|exports}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-entity",
 ]
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "serde",
  "serde_derive",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-codegen-shared",
  "pulley-interpreter",
@@ -307,12 +307,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 
 [[package]]
 name = "cranelift-control"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "arbitrary",
 ]
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -341,12 +341,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 
 [[package]]
 name = "cranelift-native"
 version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cfg-if",
 ]
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "base64",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1978,12 +1978,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cc",
@@ -2048,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "cc",
  "object",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-math"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "libm",
 ]
@@ -2078,12 +2078,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-slab"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "heck",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "heck",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2263,7 +2263,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasip3-prototyping#469ef15835d93452ec9193a8e38731c5e2bd64d1"
+source = "git+https://github.com/bytecodealliance/wasip3-prototyping#e4ffbf17258e26b7e19fdcd404481d99bafa0f13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",


### PR DESCRIPTION
Previously, the `wasm_runner` code had disabled the `concurrent_imports` and `concurrent_exports` binding generation options, which prevented any kind of guest-level concurrency.  Also, there seems to be a bug in the `wasip3-prototyping` fork of Wasmtime such that calling an async-lifted export using `TypedFunc::call_async` instead of `TypedFunc::call_concurrent` leads to a "wasm trap: async-lifted export failed to produce a result" error.  That's not super surprising since we haven't bothered to test that scenario yet, but we'll need to address it eventually.